### PR TITLE
Prevent PHP (7) Error

### DIFF
--- a/library/Twitter/Bootstrap3/Form.php
+++ b/library/Twitter/Bootstrap3/Form.php
@@ -424,7 +424,8 @@ abstract class Twitter_Bootstrap3_Form extends Zend_Form
     {
         if ($element instanceof Zend_Form_Element) {
             // type string
-            $type = lcfirst(trim(end(explode('_', $element->getType()))));
+			$exploderesult = explode('_', $element->getType());
+            $type = lcfirst(trim(end($exploderesult)));
 
             if (null !== $options && $options instanceof Zend_Config) {
                 $options = $options->toArray();

--- a/library/Twitter/Bootstrap3/Form/Decorator/ViewHelper.php
+++ b/library/Twitter/Bootstrap3/Form/Decorator/ViewHelper.php
@@ -33,6 +33,11 @@ class Twitter_Bootstrap3_Form_Decorator_ViewHelper extends Zend_Form_Decorator_V
         unset($attribs['success']);        // Twitter_Bootstrap3_Form_Decorator_Container
         unset($attribs['warning']);        // Twitter_Bootstrap3_Form_Decorator_Container
         
+		//Remove dimensions if any
+		unset($attribs['dimensionLabel']);
+		unset($attribs['dimensionControls']);
+		unset($attribs['dimension']);
+        
         return $attribs;
     }
 }


### PR DESCRIPTION
Solve error with strict standards: Only variables should be passed by reference
